### PR TITLE
[feat] 시간대 설정 재정립

### DIFF
--- a/src/main/java/com/kbslblog_api/config/JacksonConfig.java
+++ b/src/main/java/com/kbslblog_api/config/JacksonConfig.java
@@ -1,0 +1,43 @@
+package com.kbslblog_api.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.TimeZone;
+
+@Configuration
+public class JacksonConfig {
+
+    private static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
+    
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        // JVM 기본 시간대를 Asia/Seoul로 설정
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+        
+        ObjectMapper objectMapper = new ObjectMapper();
+        
+        // Java 8 날짜/시간 모듈 등록
+        JavaTimeModule javaTimeModule = new JavaTimeModule();
+        
+        // LocalDateTime 직렬화 시 Asia/Seoul 시간대 적용
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DATE_TIME_FORMAT)
+                .withZone(ZoneId.of("Asia/Seoul"));
+        
+        javaTimeModule.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(dateTimeFormatter));
+        
+        objectMapper.registerModule(javaTimeModule);
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        
+        return objectMapper;
+    }
+} 

--- a/src/main/java/com/kbslblog_api/config/TimeZoneConfig.java
+++ b/src/main/java/com/kbslblog_api/config/TimeZoneConfig.java
@@ -1,0 +1,17 @@
+package com.kbslblog_api.config;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.TimeZone;
+
+@Configuration
+public class TimeZoneConfig {
+
+    @PostConstruct
+    public void init() {
+        // 애플리케이션 시작 시 JVM 기본 시간대를 Asia/Seoul로 설정
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+        System.out.println("시스템 기본 시간대: " + TimeZone.getDefault().getID());
+    }
+} 

--- a/src/main/java/com/kbslblog_api/entity/ImageFile.java
+++ b/src/main/java/com/kbslblog_api/entity/ImageFile.java
@@ -33,6 +33,6 @@ public class ImageFile {
 
     @PrePersist
     protected void onCreate() {
-        createdAt = LocalDateTime.now();
+        createdAt = LocalDateTime.now(java.time.ZoneId.of("Asia/Seoul"));
     }
 }

--- a/src/main/java/com/kbslblog_api/entity/Post.java
+++ b/src/main/java/com/kbslblog_api/entity/Post.java
@@ -60,13 +60,15 @@ public class Post {
 
     @PrePersist
     public void prePersist() {
-        LocalDateTime now = LocalDateTime.now();
+        // 현재 시간을 Asia/Seoul 시간대로 명시적 설정
+        LocalDateTime now = LocalDateTime.now(java.time.ZoneId.of("Asia/Seoul"));
         this.createdAt = now;
         this.updatedAt = now;
     }
 
     @PreUpdate
     public void preUpdate() {
-        this.updatedAt = LocalDateTime.now();
+        // 현재 시간을 Asia/Seoul 시간대로 명시적 설정
+        this.updatedAt = LocalDateTime.now(java.time.ZoneId.of("Asia/Seoul"));
     }
 }

--- a/src/main/java/com/kbslblog_api/entity/PostLike.java
+++ b/src/main/java/com/kbslblog_api/entity/PostLike.java
@@ -39,6 +39,7 @@ public class PostLike {
 
     @PrePersist
     public void prePersist() {
-        this.likedAt = LocalDateTime.now();
+        // 현재 시간을 Asia/Seoul 시간대로 명시적 설정
+        this.likedAt = LocalDateTime.now(java.time.ZoneId.of("Asia/Seoul"));
     }
 }

--- a/src/main/java/com/kbslblog_api/service/FileUploadService.java
+++ b/src/main/java/com/kbslblog_api/service/FileUploadService.java
@@ -641,7 +641,8 @@ public class FileUploadService {
                 ps.setString(2, image.getUrl());
                 ps.setLong(3, image.getFileSize() != null ? image.getFileSize() : 0);
                 ps.setString(4, image.getMimeType());
-                ps.setObject(5, image.getCreatedAt() != null ? image.getCreatedAt() : java.time.LocalDateTime.now());
+                ps.setObject(5, image.getCreatedAt() != null ? image.getCreatedAt() : 
+                   java.time.LocalDateTime.now(java.time.ZoneId.of("Asia/Seoul")));
             }
             
             @Override


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 시스템 타임스탬프가 "Asia/Seoul" 시간대로 통일되어, 게시물, 이미지, 좋아요 및 파일 업로드 기록의 시간이 더욱 정확하게 관리됩니다.
  - 새로운 구성 기능이 추가되어, 날짜 및 시간 처리의 일관성과 신뢰성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->